### PR TITLE
chore: remove the "-temp" part of the shortcut name in the extension

### DIFF
--- a/frontend/extension/src/components/CreateShortcutsButton.tsx
+++ b/frontend/extension/src/components/CreateShortcutsButton.tsx
@@ -7,7 +7,7 @@ import { Visibility } from "@/types/proto/api/v2/common";
 import { CreateShortcutResponse, OpenGraphMetadata } from "@/types/proto/api/v2/shortcut_service";
 import Icon from "./Icon";
 
-const generateTempName = (length = 8) => {
+const generateName = (length = 8) => {
   let result = "";
   const characters = "abcdefghijklmnopqrstuvwxyz0123456789";
   const charactersLength = characters.length;
@@ -54,7 +54,7 @@ const CreateShortcutsButton = () => {
       const tab = tabs[0];
       setState((state) => ({
         ...state,
-        name: generateTempName() + "-temp",
+        name: generateName(),
         title: tab.title || "",
         link: tab.url || "",
       }));

--- a/frontend/extension/src/components/CreateShortcutsButton.tsx
+++ b/frontend/extension/src/components/CreateShortcutsButton.tsx
@@ -7,7 +7,7 @@ import { Visibility } from "@/types/proto/api/v2/common";
 import { CreateShortcutResponse, OpenGraphMetadata } from "@/types/proto/api/v2/shortcut_service";
 import Icon from "./Icon";
 
-const generateTempName = (length = 6) => {
+const generateTempName = (length = 8) => {
   let result = "";
   const characters = "abcdefghijklmnopqrstuvwxyz0123456789";
   const charactersLength = characters.length;


### PR DESCRIPTION
This pull request removes "-temp" part of the shortcut name as I feel it's unnecessary and increases the random name length.
I haven't tested it, though it shouldn't have any reason to not work.