### PR TITLE
fix: public shortcuts not showing up in public collections

### DIFF
--- a/api/v2/acl_config.go
+++ b/api/v2/acl_config.go
@@ -10,6 +10,7 @@ var allowedMethodsWhenUnauthorized = map[string]bool{
 	"/slash.api.v2.AuthService/SignOut":                   true,
 	"/memos.api.v2.AuthService/GetAuthStatus":             true,
 	"/slash.api.v2.ShortcutService/GetShortcutByName":     true,
+	"/slash.api.v2.ShortcutService/GetShortcut":           true,
 	"/slash.api.v2.CollectionService/GetCollectionByName": true,
 }
 


### PR DESCRIPTION
Collection page uses GetShortcut to get shortcut info, which should allow unauthorized access.