### PR TITLE
feat: add open-all-shortcuts button to collection

### DIFF
--- a/frontend/web/src/components/CollectionView.tsx
+++ b/frontend/web/src/components/CollectionView.tsx
@@ -55,6 +55,10 @@ const CollectionView = (props: Props) => {
     navigateTo(`/shortcut/${shortcut.id}`);
   };
 
+  const handleOpenAllShortcutsButtonClick = () => {
+    shortcuts.forEach((shortcut: Shortcut) => window.open(`/s/${shortcut.name}`));
+  };
+
   return (
     <>
       <div className={classNames("w-full flex flex-col justify-start items-start border rounded-lg hover:shadow dark:border-zinc-800")}>
@@ -74,6 +78,9 @@ const CollectionView = (props: Props) => {
             <Link className="w-full text-gray-400 cursor-pointer hover:text-gray-500" to={`/c/${collection.name}`} target="_blank">
               <Icon.Share className="w-4 h-auto" />
             </Link>
+            <button className="w-full text-gray-400 cursor-pointer hover:text-gray-500" onClick={() => handleOpenAllShortcutsButtonClick()}>
+              <Icon.ArrowUpRight className="w-4 h-auto" />
+            </button>
             {showAdminActions && (
               <Dropdown
                 trigger={


### PR DESCRIPTION
In /collection view, next to "Share" button, adds an "ArrowUpRight" button that opens all shortcuts in collection on click.

(By default, browser might block multiple tabs from opening at once but rather only open the first one; usually a pop-up or warning appears, where the user can allow the opening of multiple tabs at once by the site). I think, despite this restriction, it is a very useful button I'd like to see in this awesome app!