### PR TITLE
fix: URL redirection issue

### DIFF
--- a/frontend/extension/src/background.ts
+++ b/frontend/extension/src/background.ts
@@ -13,7 +13,8 @@ chrome.webRequest.onBeforeRequest.addListener(
       const shortcutName = getShortcutNameFromUrl(param.url);
       if (shortcutName) {
         const instanceUrl = (await storage.getItem<string>("instance_url")) || "";
-        return chrome.tabs.update({ url: `${instanceUrl}/s/${shortcutName}` });
+        const url = new URL(`/s/${shortcutName}`, instanceUrl);
+        return chrome.tabs.update({ url: url.toString() });
       }
     })();
   },


### PR DESCRIPTION
This PR fixes a bug where the extension was adding an extra slash (//) in the URL during redirection. The problem happened because the stored instance_url might already have a slash at the end, causing the double slash when combined with the shortcut path.

Changes:

- Updated the URL construction logic in background.ts to use the URL object.
- This change ensures that URLs are correctly formatted, preventing the occurrence of double slashes in the redirection path.

Testing:

- Verified that the redirection works correctly with instance_url values both with and without trailing slashes.
- Tested with various shortcut paths to ensure consistent behavior.